### PR TITLE
Reoder init in GUIConnectionWithBlocks

### DIFF
--- a/src/blocks_gui/connection/connection_with_blocks_gui.py
+++ b/src/blocks_gui/connection/connection_with_blocks_gui.py
@@ -19,6 +19,8 @@ class GUIConnectionWithBlocks(GUIConnection):
         
         super().__init__(model, view, start_block, "RIGHT", end_block=end_block, end_direction="LEFT")
         
+        self.__is_deleted = False
+        
         # Move start block to specified coordinate
         if start_coordinate != None:
             start_block.move_block(start_coordinate[0] - start_block.get_x(), \
@@ -38,7 +40,6 @@ class GUIConnectionWithBlocks(GUIConnection):
             self.__input_scalars_indicator.move_block(input_scalars_indicator_coordinate[0] - self.__input_scalars_indicator.get_x(), \
                                                       input_scalars_indicator_coordinate[1] - self.__input_scalars_indicator.get_y())
             
-        self.__is_deleted = False
         
     def scale(self, new_length_unit, last_length_unit):
         super().scale(new_length_unit, last_length_unit)


### PR DESCRIPTION
When using the GUI, the connection is first setup at a default position. It is then correctly initialized, and only later are its endpoints moved to specific positions.

However, the attribute `_GUIConnectionWithBlocks__is_deleted` is initialized at the end of the `__init__` method, which causes the program to crash if the connection is created from the start with its endpoints correctly set on the respective endpoints of an existing connection. This is due to the calls to `push_down_block()` that will happen if the endpoints are defined.

The problem disappears by moving the initialization higher up.